### PR TITLE
Add WEBSOCKET_LOG_URL to installation guide

### DIFF
--- a/install/install.md
+++ b/install/install.md
@@ -47,10 +47,9 @@ MAILER_PASSWORD = <mailer_pass>
 FRONTEND_URL = http://localhost:3000
 AUTH_HTTP_PORT = 5000
 AUTH_GRPC_PORT = 5001
-
+WEBSOCKET_LOG_URL = ws://host.docker.internal:5002/live
 RUNNER_CONTROLLER_HTTP_PORT = 5002
 AUTH_GRPC_ADDRESS = host.docker.internal:5001
-
 
 NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:5002
 NEXT_PUBLIC_AUTH_BASE_URL=http://localhost:5000


### PR DESCRIPTION
Include WEBSOCKET_LOG_URL in the environment variables section of the installation guide for better configuration clarity.