### PR TITLE
docs: add Gemini API key setup to backend deployment guide

### DIFF
--- a/install/install.md
+++ b/install/install.md
@@ -62,6 +62,45 @@ GOOGLE_GENERATIVE_AI_API_KEY=<YOUR_GEMINI_API_KEY>
 
 ![env-content](https://i.imgur.com/1uGj3rU.png)
 
+
+## Obtain a Gemini API Key (Optional – Required for AI Features)
+
+EvOC supports AI-powered features using Google’s **Gemini API**.  
+To enable these features, you must obtain a Gemini API key and add it to your `.env` file.
+
+### Steps to get a Gemini API key
+
+1. Visit **Google AI Studio**:  
+   https://aistudio.google.com/
+
+2. Sign in with your Google account.
+
+3. Click **Get API key** → **Create API key**.
+
+4. Select an existing Google Cloud project or create a new one.
+
+5. Copy the generated API key.
+
+### Enable AI features
+
+In your `.env` file:
+```env
+NEXT_PUBLIC_AI=true
+GOOGLE_GENERATIVE_AI_API_KEY=<YOUR_GEMINI_API_KEY>
+```
+
+
+If you do not want AI features, keep:
+```
+NEXT_PUBLIC_AI=false
+```
+
+::: warning
+Do not commit your API key to version control.
+The .env file should remain private and untracked.
+:::
+
+
 ## Run Services
 
 Run all services using the Docker Compose `.yml` file. Execute this command inside the `operations` directory:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,6 +2091,14 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/search-insights": {
+            "version": "2.17.3",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+            "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/shiki": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",


### PR DESCRIPTION
### Changes

- Added a new section to the **Backend Setup** guide explaining:
  - How to obtain a Gemini API key via Google AI Studio
  - How to enable/disable AI features using environment variables
- Positioned the section before service startup to prevent setup confusion

<img width="768" height="836" alt="Screenshot from 2026-01-04 21-13-47" src="https://github.com/user-attachments/assets/00cccacf-8d9a-4968-bf34-fc6c7e0888f3" />

solves #6 
@Ashrockzzz2003 